### PR TITLE
updated EX1.12_One_word_per_line.c

### DIFF
--- a/C_exercises/EX1.12_One_word_per_line.c
+++ b/C_exercises/EX1.12_One_word_per_line.c
@@ -5,7 +5,7 @@
 #define IN 1 	// inspace (blank. tab, or newline)
 #define OUT 0	// outspace
 
-void main()
+main()
 {
 	int c, state;
 


### PR DESCRIPTION
changed void main to main as most compilers(online IDE codechef) were showing error.
RUNTIME ERROR
NZEC